### PR TITLE
Bug Fix : Invalid json added to payload when not specifying in_MAC or out_MAC

### DIFF
--- a/move_by_attribute/process_move.py
+++ b/move_by_attribute/process_move.py
@@ -25,12 +25,14 @@ LOGIN_MAC = args.in_MAC
 LOGOUT_MAC = args.out_MAC
 
 to_seat_id = 0
-if (len(table_macs_to_seats.search(Query().mac == LOGIN_MAC)) > 0):
-    to_seat_id = table_macs_to_seats.search(Query().mac == LOGIN_MAC)[0]['seat']
+if LOGIN_MAC:
+	if (len(table_macs_to_seats.search(Query().mac == LOGIN_MAC)) > 0):
+	    to_seat_id = table_macs_to_seats.search(Query().mac == LOGIN_MAC)[0]['seat']
 
 from_seat_id = 0
-if (len(table_macs_to_seats.search(Query().mac == LOGOUT_MAC)) > 0):
-    from_seat_id = table_macs_to_seats.search(Query().mac == LOGOUT_MAC)[0]['seat']
+if LOGOUT_MAC:
+	if (len(table_macs_to_seats.search(Query().mac == LOGOUT_MAC)) > 0):
+	    from_seat_id = table_macs_to_seats.search(Query().mac == LOGOUT_MAC)[0]['seat']
 
 move_body = {'employee_id': EMPLOYEE_EMAIL.split('@', 1)[0],
              'move_time': str(datetime.datetime.now().replace(microsecond=0)),


### PR DESCRIPTION
Fixes bug whereby when not submitting an in_MAC or out_MAC would result in the database being searched regardless, comparing the contents to a non-existent value. This resulted in invalid json being added to the payload sent to the api and certain requests to fail. This patch, makes it so the database is only queried when there is an in_MAC or out_MAC specified by the user.